### PR TITLE
Append system response to chat history

### DIFF
--- a/backend/app/hyse/hypo_schema_search.py
+++ b/backend/app/hyse/hypo_schema_search.py
@@ -34,6 +34,7 @@ def hyse_search(initial_query):
     query_embedding = openai_client.generate_embeddings(text=initial_query)
     initial_results = cos_sim_search(query_embedding, column_name="query_embed")
     
+    return initial_results
     initial_results_formatted = format_cos_sim_results(initial_results)
     
     return initial_results_formatted


### PR DESCRIPTION
The PR addresses Issue #3 by refactoring the handling of chat history. Below is an example of the updated chat history format:

```
{
  thread_id_1:[
    {
      "sender":"user",
      "text":"I want to build a machine learning model to predict weather",
      "mention_semantic_fields":true,
      "mention_raw_fields":false
    },
    {
      "sender":"system",
      "text":[],
      "refine_type":"semantic"
    },
  ],
  thread_id_2:[]
}
```