### PR TITLE
Handle intermediate results caching

### DIFF
--- a/backend/app/actions/handle_action.py
+++ b/backend/app/actions/handle_action.py
@@ -2,18 +2,18 @@ from backend.app.hyse.hypo_schema_search import hyse_search
 from backend.app.actions.infer_action import text_to_sql, execute_sql
 import logging
 
-def handle_semantic_fields(chat_history, thread_id):
+def handle_semantic_fields(chat_history, thread_id, search_space):
     # Run refined hyse again: combine all previous semantic related queries
     # Filter messages where 'mention_semantic_fields' is True
     semantic_queries = [message['text'] for message in chat_history[thread_id] if message.get('mention_semantic_fields')]
     # Concatenate the filtered messages into a single string
     semantic_queries_comb = ' '.join(semantic_queries)
     # Run hyse again
-    refined_results = hyse_search(semantic_queries_comb)
+    refined_results = hyse_search(semantic_queries_comb, search_space)
 
     return refined_results
 
-def handle_raw_fields(cur_query, inferred_raw_fields):
+def handle_raw_fields(cur_query, inferred_raw_fields, search_space):
     # Excute text to sql
     sql_clauses = text_to_sql(cur_query, inferred_raw_fields)
     logging.info(f"✅Inferred SQL clauses for current query '{cur_query}': {sql_clauses.model_dump()}")
@@ -23,6 +23,6 @@ def handle_raw_fields(cur_query, inferred_raw_fields):
         logging.info(sql_clause.field)
         logging.info(sql_clause.clause)
     
-    refined_results = execute_sql(sql_clauses)
+    refined_results = execute_sql(sql_clauses, search_space)
 
     return refined_results

--- a/backend/app/chat/handle_chat_history.py
+++ b/backend/app/chat/handle_chat_history.py
@@ -15,10 +15,12 @@ def append_user_query(chat_history, thread_id, text, mention_semantic_fields=Non
     # logging.info(f"💬User input query added to chat history for thread_id {thread_id}: {text}")
 
 def append_system_response(chat_history, thread_id, text, refine_type):
-    # Append a system response to the chat history
+    table_names = [result["table_name"] for result in text]
+    
+    # Append a system response to the chat history 
     response = {
         "sender": "system",
-        "text": text,
+        "text": table_names,
         "refine_type": refine_type
     }
 

--- a/backend/app/hyse/hypo_schema_search.py
+++ b/backend/app/hyse/hypo_schema_search.py
@@ -20,7 +20,7 @@ class TableSchema(BaseModel):
     data_types: list[str]
 
 
-def hyse_search(initial_query):
+def hyse_search(initial_query, search_space=None):
     # Step 1: Infer hypothetical schema
     hypo_schema_json = infer_hypothetical_schema(initial_query).json()
 
@@ -28,16 +28,13 @@ def hyse_search(initial_query):
     hypo_schema_embedding = openai_client.generate_embeddings(text=hypo_schema_json)
 
     # Step 3: Cosine similarity search between e(hypo_schema_embed) and e(existing_scheme_embed)
-    initial_results = cos_sim_search(hypo_schema_embedding)
+    initial_results = cos_sim_search(hypo_schema_embedding, search_space)
     
     # Step 4: Cosine similarity search between e(query) and e(existing_prev_queries_embed)
     query_embedding = openai_client.generate_embeddings(text=initial_query)
-    initial_results = cos_sim_search(query_embedding, column_name="query_embed")
+    initial_results = cos_sim_search(query_embedding, search_space, column_name="query_embed")
     
     return initial_results
-    initial_results_formatted = format_cos_sim_results(initial_results)
-    
-    return initial_results_formatted
 
 
 def infer_hypothetical_schema(initial_query):
@@ -52,18 +49,29 @@ def infer_hypothetical_schema(initial_query):
 
     return openai_client.infer_metadata(messages, response_model)
 
-def cos_sim_search(input_embedding, column_name="comb_embed"):
+def cos_sim_search(input_embedding, search_space, column_name="comb_embed"):
     if column_name not in ["comb_embed", "query_embed"]:
         raise ValueError("Invalid embedding column")
     
     with DatabaseConnection() as db:
-        query = f"""
-            SELECT table_name, 1 - ({column_name} <=> %s::VECTOR(1536)) AS cosine_similarity
-            FROM corpus_raw_metadata_with_embedding
-            ORDER BY cosine_similarity DESC;
-        """
-
-        db.cursor.execute(query, (input_embedding,))
+        if search_space:
+            # Filter by specific table names
+            query = f"""
+                SELECT table_name, 1 - ({column_name} <=> %s::VECTOR(1536)) AS cosine_similarity
+                FROM corpus_raw_metadata_with_embedding
+                WHERE table_name = ANY(%s)
+                ORDER BY cosine_similarity DESC;
+            """
+            db.cursor.execute(query, (input_embedding, search_space))
+        else:
+            # No specific search space, search through all table names
+            query = f"""
+                SELECT table_name, 1 - ({column_name} <=> %s::VECTOR(1536)) AS cosine_similarity
+                FROM corpus_raw_metadata_with_embedding
+                ORDER BY cosine_similarity DESC;
+            """
+            db.cursor.execute(query, (input_embedding, ))
+        
         results = db.cursor.fetchall()
     
     return results


### PR DESCRIPTION
This PR addresses Issue #7.

The `refine_search_space` endpoint has been updated to limit the search space to the previous results set when refining based on semantic or raw metadata fields.