### PR TITLE
Enable user manually reset search space

### DIFF
--- a/frontend/my-app/src/components/ResultsTable.js
+++ b/frontend/my-app/src/components/ResultsTable.js
@@ -3,27 +3,44 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Button from '@mui/material/Button';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 
-const ResultsTable = ({ results }) => {
+const ResultsTable = ({ results, onResetSearch }) => {
     return (
-        <Table size="small" aria-label="a dense table">
-            <TableHead>
-                <TableRow>
-                    <TableCell sx={{ color: '#ABADC6', fontWeight: 'bold' }}>Index</TableCell>
-                    <TableCell sx={{ color: '#ABADC6', fontWeight: 'bold' }}>Table Name</TableCell>
-                </TableRow>
-            </TableHead>
-            <TableBody>
-                {results.map((row, index) => (
-                    <TableRow key={index}>
-                        <TableCell component="th" scope="row" sx={{ color: '#ABADC6' }}>
-                            {index + 1}
-                        </TableCell>
-                        <TableCell sx={{ color: '#ABADC6' }}>{row.table_name}</TableCell>
+        <div>
+            <Table size="small" aria-label="a dense table">
+                <TableHead>
+                    <TableRow>
+                        <TableCell sx={{ color: '#ABADC6', fontWeight: 'bold' }}>Index</TableCell>
+                        <TableCell sx={{ color: '#ABADC6', fontWeight: 'bold' }}>Table Name</TableCell>
                     </TableRow>
-                ))}
-            </TableBody>
-        </Table>
+                </TableHead>
+                <TableBody>
+                    {results.map((row, index) => (
+                        <TableRow key={index}>
+                            <TableCell component="th" scope="row" sx={{ color: '#ABADC6' }}>
+                                {index + 1}
+                            </TableCell>
+                            <TableCell sx={{ color: '#ABADC6' }}>{row.table_name}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+
+            <Button
+                variant="outlined"
+                size="small"
+                startIcon={<RestartAltIcon />}
+                onClick={onResetSearch}
+                sx={{
+                    margin: '15px 0px',
+                    fontSize: '0.8rem',
+                }}
+            >
+                Reset Search Space from Here
+            </Button>
+        </div>
     );
 };
 


### PR DESCRIPTION
This PR addresses Issue #9. We provide users with the ability to manually reset the current search space to a previous state. This allows users to correct any errors that may arise from LLM's pruning decisions and maintain the accuracy and relevance of their search results.

For each returned system result, a reset button is appended below the results table. When the user clicks this button, they can reset the current search space to that specific results set.

<img width="801" alt="image" src="https://github.com/Gitcatmeoww/HITS-system-implementation/assets/100456027/5c66d47a-15f2-48c6-b342-26af6bd97c08">