### PR TITLE
Adjust search refinement to include finer granularities

### DIFF
--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,1 +1,1 @@
-from .utils import format_prompt, run_sql_file, extract_time_geo_granularity, format_cos_sim_results, clean_json_string, validate_and_load_json, extract_granularities, load_json_file
+from .utils import format_prompt, run_sql_file, extract_time_geo_granularity, format_cos_sim_results, clean_json_string, validate_and_load_json, extract_granularities, load_json_file, get_finer_granularities

--- a/backend/app/utils/utils.py
+++ b/backend/app/utils/utils.py
@@ -111,3 +111,10 @@ def extract_granularities(json_data):
             geo_granu.append(table["Geographic granularity"])
     
     return time_granu, geo_granu
+
+def get_finer_granularities(granularity, order_list):
+        """ Return the finer granularities including the specified one """
+        if granularity.lower() in order_list:
+            index = order_list.index(granularity.lower())
+            return order_list[:index + 1]
+        return []


### PR DESCRIPTION
This PR addresses Issue #12. 

This update ensures that both the identified temporal or geographic granularity and all finer granularities are included in the SQL clause when refining search results. Two predefined lists for temporal and geographic granularity are structured hierarchically to facilitate the inclusion of finer granularities.