### PR TITLE
Support multiple HySE search

### DIFF
--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -92,7 +92,7 @@ def initial_search():
         return jsonify({"error": "No query provided"}), 400
 
     try:
-        initial_results = hyse_search(initial_query, search_space=None)
+        initial_results = hyse_search(initial_query, search_space=None, num_schema=1, k=50)  # Keep top 50 results in initial search
         append_system_response(chat_history, thread_id, initial_results, refine_type="semantic")
 
         # Update the cached results

--- a/backend/app/hyse/hypo_schema_search.py
+++ b/backend/app/hyse/hypo_schema_search.py
@@ -2,15 +2,22 @@ from backend.app.table_representation.openai_client import OpenAIClient
 from backend.app.utils import format_prompt, format_cos_sim_results
 from backend.app.db.connect_db import DatabaseConnection
 from pydantic import BaseModel
+from typing import List
+import logging
 
 # Initialize OpenAI client
 openai_client = OpenAIClient()
 
 # Craft schema inference prompt
-# TODO: generate multiple hypothetical schemas
-PROMPT = """
+PROMPT_SINGLE_SCHEMA = """
 Given the objective of {query}, help me generate a hypothetical table schema to support this.
 Only generate one table schema, excluding any introductory phrases and focusing exclusively on the tasks themselves.
+"""
+
+PROMPT_MULTI_SCHEMA = """
+Given the objective of {query}, help me generate {num_schema} normalized hypothetical table schema to support this.
+Generate the schemas as a JSON array of objects, where each object represents a normalized schema.
+Excluding any introductory phrases and focusing exclusively on the tasks themselves.
 """
 
 # TODO: refactor pydantic models
@@ -20,25 +27,43 @@ class TableSchema(BaseModel):
     data_types: list[str]
 
 
-def hyse_search(initial_query, search_space=None):
-    # Step 1: Infer hypothetical schema
-    hypo_schema_json = infer_hypothetical_schema(initial_query).json()
+def hyse_search(initial_query, search_space=None, num_schema=1, k=10):
+    # Step 0: Initialize the results list
+    results = []
+    # Determine k for single & multiple HySE evaluation
+    k_single = k // num_schema + (k % num_schema > 0)
+    k_multi = k // num_schema
 
-    # Step 2: Generate embedding for the hypothetical schema
-    hypo_schema_embedding = openai_client.generate_embeddings(text=hypo_schema_json)
+    # Step 1: Single HySE search
+    # Step 1.1: Infer a single denormalized hypothetical schema
+    single_hypo_schema_json = infer_single_hypothetical_schema(initial_query).json()
 
-    # Step 3: Cosine similarity search between e(hypo_schema_embed) and e(existing_scheme_embed)
-    initial_results = cos_sim_search(hypo_schema_embedding, search_space)
+    # Step 1.2: Generate embedding for the single hypothetical schema
+    single_hypo_schema_embedding = openai_client.generate_embeddings(text=single_hypo_schema_json)
+
+    # Step 1.3: Cosine similarity search between e(hypo_schema_embed) and e(existing_scheme_embed)
+    single_hyse_results = cos_sim_search(single_hypo_schema_embedding, search_space, k_single)
+    results.append(single_hyse_results)
     
-    # Step 4: Cosine similarity search between e(query) and e(existing_prev_queries_embed)
-    query_embedding = openai_client.generate_embeddings(text=initial_query)
-    initial_results = cos_sim_search(query_embedding, search_space, column_name="query_embed")
-    
-    return initial_results
+    # Step 2: Multiple HySE search (N > 1)
+    if num_schema > 1:
+        # Step 2.1: Infer multiple normalized hypothetical schemas
+        multi_hypo_schemas_json = infer_multiple_hypothetical_schema(initial_query, num_schema - 1).json()
 
+        # Step 2.2: Generate embeddings for the multiple hypothetical schemas
+        multi_hypo_schemas_embeddings = [openai_client.generate_embeddings(text=schema) for schema in multi_hypo_schemas_json]
 
-def infer_hypothetical_schema(initial_query):
-    prompt = format_prompt(PROMPT, query=initial_query)
+        # Step 2.3: Cosine similarity search for each multiple hypothetical schema embedding
+        for hypo_schema_embedding in multi_hypo_schemas_embeddings:
+            results.append(cos_sim_search(hypo_schema_embedding, search_space, k_multi))
+
+    # Step 3: Aggregate results from single & multiple HySE searches
+    aggregated_results = aggregate_hyse_search_results(results)
+
+    return aggregated_results
+
+def infer_single_hypothetical_schema(initial_query):
+    prompt = format_prompt(PROMPT_SINGLE_SCHEMA, query=initial_query)
 
     response_model = TableSchema
 
@@ -49,7 +74,19 @@ def infer_hypothetical_schema(initial_query):
 
     return openai_client.infer_metadata(messages, response_model)
 
-def cos_sim_search(input_embedding, search_space, column_name="comb_embed"):
+def infer_multiple_hypothetical_schema(initial_query, num_schema):
+    prompt = format_prompt(PROMPT_MULTI_SCHEMA, query=initial_query, num_schema=num_schema)
+
+    response_model = List[TableSchema]
+
+    messages = [
+        {"role": "system", "content": "You are an assistant skilled in generating normalized database schemas."},
+        {"role": "user", "content": prompt}
+    ]
+
+    return openai_client.infer_metadata(messages, response_model)
+
+def cos_sim_search(input_embedding, search_space, k, column_name="comb_embed"):
     if column_name not in ["comb_embed", "query_embed"]:
         raise ValueError("Invalid embedding column")
     
@@ -60,18 +97,48 @@ def cos_sim_search(input_embedding, search_space, column_name="comb_embed"):
                 SELECT table_name, 1 - ({column_name} <=> %s::VECTOR(1536)) AS cosine_similarity
                 FROM corpus_raw_metadata_with_embedding
                 WHERE table_name = ANY(%s)
-                ORDER BY cosine_similarity DESC;
+                ORDER BY cosine_similarity DESC
+                LIMIT %s;
             """
-            db.cursor.execute(query, (input_embedding, search_space))
+            db.cursor.execute(query, (input_embedding, search_space, k))
         else:
             # No specific search space, search through all table names
             query = f"""
                 SELECT table_name, 1 - ({column_name} <=> %s::VECTOR(1536)) AS cosine_similarity
                 FROM corpus_raw_metadata_with_embedding
-                ORDER BY cosine_similarity DESC;
+                ORDER BY cosine_similarity DESC
+                LIMIT %s;
             """
-            db.cursor.execute(query, (input_embedding, ))
+            db.cursor.execute(query, (input_embedding, k))
         
         results = db.cursor.fetchall()
     
-    return results
+    # Ensure results are correctly structured
+    formatted_results = [{'table_name': row['table_name'], 'cosine_similarity': float(row['cosine_similarity'])} for row in results]
+    return formatted_results
+
+def aggregate_hyse_search_results(results):
+    # Flatten the list of results
+    flat_results = [item for sublist in results for item in sublist]
+    
+    # Aggregate by table name and calculate mean cosine similarity
+    aggregated_results = {}
+    for result in flat_results:
+        table_name = result['table_name']
+        cosine_similarity = result['cosine_similarity']
+        
+        if not isinstance(cosine_similarity, (int, float)):
+            logging.error(f"Unexpected type for cosine_similarity: {type(cosine_similarity)} with value {cosine_similarity}")
+            raise ValueError(f"Unexpected type for cosine_similarity: {type(cosine_similarity)}")
+        
+        if table_name in aggregated_results:
+            aggregated_results[table_name].append(cosine_similarity)
+        else:
+            aggregated_results[table_name] = [cosine_similarity]
+    
+    # Calculate the mean cosine similarity for each table
+    final_results = [{'table_name': table_name, 'cosine_similarity': sum(similarities) / len(similarities)} for table_name, similarities in aggregated_results.items()]
+    
+    # Sort the final results by mean cosine similarity in descending order
+    final_results.sort(key=lambda x: x['cosine_similarity'], reverse=True)
+    return final_results

--- a/backend/app/table_representation/openai_client.py
+++ b/backend/app/table_representation/openai_client.py
@@ -8,17 +8,17 @@ load_dotenv()
 
 class OpenAIClient:
     def __init__(self):
-        # self.client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
-        # self.text_generation_model_default = "gpt-3.5-turbo"
-        # self.embedding_model_default = "text-embedding-3-small"
-        self.client = AzureOpenAI(
-            azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT"), 
-            api_key=os.getenv("AZURE_OPENAI_API_KEY"),  
-            api_version="2024-02-15-preview"
-        ) 
-        # self.text_generation_model_default = "gpt-35-infer-model"
-        self.text_generation_model_default = "gpt-4-infer-model"
-        self.embedding_model_default = "gpt-4-embed-ada-model"
+        self.client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
+        self.text_generation_model_default = "gpt-4o"
+        self.embedding_model_default = "text-embedding-3-small"
+        # self.client = AzureOpenAI(
+        #     azure_endpoint = os.getenv("AZURE_OPENAI_ENDPOINT"), 
+        #     api_key=os.getenv("AZURE_OPENAI_API_KEY"),  
+        #     api_version="2024-02-15-preview"
+        # ) 
+        # # self.text_generation_model_default = "gpt-35-infer-model"
+        # self.text_generation_model_default = "gpt-4-infer-model"
+        # self.embedding_model_default = "gpt-4-embed-ada-model"
 
     def infer_metadata(self, messages, response_model, model=None):
         if model is None:


### PR DESCRIPTION
This PR addresses Issue #14.

The primary enhancement is the expansion of `hyse_search` function to support multi-HySE search. Two additional arguments are introduced: `num_schema` and `k`, where `num_schema` defines the total number of schemas to generate, and `k` is used for retrieval performance evaluation.

**HySE search logic:**
- Define Number of Schemas (N):
  - `num_schema` specifies the number of schemas required for the search
- Single Table Approach:
  - Initially, assume the analytical task can be approached using a single denormalized table
  - Generate a single hypothetical schema and retrieve results
- Multiple Table Approach:
  - Assume the analytical task requires more than one table
  - Generate `N-1` hypothetical schemas that could jointly solve the task and retrieve results

**Retrieval performance evaluation:**
- Distribute `k` uniformly across each schema
- If there are remainders, they are allocated to the single HySE
