### PR TITLE
Wrap hyse_search with caching logic in EvalMethods class

### DIFF
--- a/backend/app/actions/handle_action.py
+++ b/backend/app/actions/handle_action.py
@@ -9,7 +9,7 @@ def handle_semantic_fields(chat_history, thread_id, search_space):
     # Concatenate the filtered messages into a single string
     semantic_queries_comb = ' '.join(semantic_queries)
     # Run hyse again
-    refined_results = hyse_search(semantic_queries_comb, search_space)
+    refined_results, _, _ = hyse_search(semantic_queries_comb, search_space)
 
     return refined_results
 

--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -92,7 +92,7 @@ def initial_search():
         return jsonify({"error": "No query provided"}), 400
 
     try:
-        initial_results = hyse_search(initial_query, search_space=None, num_schema=1, k=50)  # Keep top 50 results in initial search
+        initial_results, _, _ = hyse_search(initial_query, search_space=None, num_schema=1, k=50)  # Keep top 50 results in initial search
         append_system_response(chat_history, thread_id, initial_results, refine_type="semantic")
 
         # Update the cached results

--- a/backend/app/evals/eval_methods.py
+++ b/backend/app/evals/eval_methods.py
@@ -4,6 +4,7 @@ import logging
 from dotenv import load_dotenv
 from backend.app.evals.elastic_search.es_client import es_client
 from backend.app.hyse.hypo_schema_search import hyse_search
+from eval_utils import get_hypo_schema_from_db, save_hypo_schema_to_db
 
 load_dotenv()
 
@@ -94,7 +95,7 @@ class EvalMethods:
     def hyse_search(self, query, num_schema=1):
         try:
             # Check if existing hypothetical schema & embedding available in DB
-            hypo_schema, hypo_schema_embed = self.get_hypo_schema_from_db(query)
+            hypo_schema, hypo_schema_embed = get_hypo_schema_from_db(query)
 
             # If NOT found in cache, call the original hyse_search function
             if hypo_schema is None or hypo_schema_embed is None:
@@ -107,7 +108,7 @@ class EvalMethods:
                     column_name=self.embed_col
                 )
                 # Save the schema & embedding to DB
-                self.save_hypo_schema_to_db(query, hypo_schema, hypo_schema_embed)
+                save_hypo_schema_to_db(query, hypo_schema, hypo_schema_embed)
             
             # If FOUND in cache, perform cosine similarity search between cached embedding and e(existing_scheme_embed)
             else:               

--- a/backend/app/evals/eval_methods.py
+++ b/backend/app/evals/eval_methods.py
@@ -93,14 +93,25 @@ class EvalMethods:
     
     def hyse_search(self, query, num_schema=1):
         try:
-            results = hyse_search(
-                query,
-                search_space=None,
-                num_schema=num_schema,
-                k=self.k,
-                table_name=self.data_split,
-                column_name=self.embed_col
-            )
+            # Check if existing hypothetical schema & embedding available in DB
+            hypo_schema, hypo_schema_embed = self.get_hypo_schema_from_db(query)
+
+            # If NOT found in cache, call the original hyse_search function
+            if hypo_schema is None or hypo_schema_embed is None:
+                results, hypo_schema, hypo_schema_embed = hyse_search(
+                    query,
+                    search_space=None,
+                    num_schema=num_schema,
+                    k=self.k,
+                    table_name=self.data_split,
+                    column_name=self.embed_col
+                )
+                # Save the schema & embedding to DB
+                self.save_hypo_schema_to_db(query, hypo_schema, hypo_schema_embed)
+            
+            # If FOUND in cache, perform cosine similarity search between cached embedding and e(existing_scheme_embed)
+            else:               
+                results = cos_sim_search(hypo_schema_embed, search_space=None, table_name=self.data_split, column_name=self.embed_col)
 
             # Extract only the table_name from each result
             return [result['table_name'] for result in results]

--- a/backend/app/evals/eval_utils.py
+++ b/backend/app/evals/eval_utils.py
@@ -1,0 +1,36 @@
+from backend.app.db.connect_db import DatabaseConnection
+import logging
+
+def get_hypo_schema_from_db(query):
+    try:
+        with DatabaseConnection() as db:
+            select_query = """
+            SELECT hypo_schema, hypo_schema_embed FROM eval_hyse_schemas
+            WHERE query = %s;
+            """
+            db.cursor.execute(select_query, (query,))
+            result = db.cursor.fetchone()
+            if result:
+                hypo_schema = result['hypo_schema']
+                hypo_schema_embed = result['hypo_schema_embed']
+                return hypo_schema, hypo_schema_embed
+            else:
+                return None, None
+    except Exception as e:
+        logging.exception(f"Error retrieving hypothetical schema from DB: {e}")
+        return None, None
+
+def save_hypo_schema_to_db(query, hypo_schema, hypo_schema_embed):
+    try:
+        with DatabaseConnection() as db:
+            insert_query = """
+            INSERT INTO eval_hyse_schemas (query, hypo_schema, hypo_schema_embed)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (query) DO UPDATE SET
+            hypo_schema = EXCLUDED.hypo_schema,
+            hypo_schema_embed = EXCLUDED.hypo_schema_embed;
+            """
+            db.cursor.execute(insert_query, (query, hypo_schema, hypo_schema_embed))
+            db.conn.commit()
+    except Exception as e:
+        logging.exception(f"Error saving hypothetical schema to DB: {e}")

--- a/backend/app/hyse/hypo_schema_search.py
+++ b/backend/app/hyse/hypo_schema_search.py
@@ -106,7 +106,7 @@ def hyse_search(initial_query, search_space=None, num_schema=1, k=10, table_name
     aggregated_results.sort(key=lambda x: x['cosine_similarity'], reverse=True)
     top_k_results = aggregated_results[:k]
 
-    return top_k_results
+    return top_k_results, single_hypo_schema_json, single_hypo_schema_embedding
 
 def infer_single_hypothetical_schema(initial_query):
     prompt = format_prompt(PROMPT_SINGLE_SCHEMA, query=initial_query)


### PR DESCRIPTION
This PR introduces a caching mechanism for hypothetical schemas and their embeddings to optimize the evaluation process. By caching these schemas, we can easily adjust retrieval parameters like `k` without additional overhead in evaluation.

Key Changes:
- **Created `eval_hyse_schemas` Table**
  - Purpose: Stores and reuses hypothetical schemas and embeddings associated with queries
  - Schema:
    > `query` (TEXT PRIMARY KEY): The task query
    > `hypo_schema` (TEXT): The generated hypothetical schema
    > `hypo_schema_embed` (VECTOR(1536)): The embedding of the hypothetical schema

- **Updated `hyse_search` Method**
  - Checks if a hypothetical schema and its embedding already exist for a given query
    - If they exist, retrieves and uses them
    - If not, generates them, stores them in the database, and proceeds
